### PR TITLE
package.json update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "array-shuffle": "^1.0.1",
     "inherits": "^2.0.1",
-    "layout-bmfont-text": "https://github.com/matterport/layout-bmfont-text#e9becf5",
+    "layout-bmfont-text": "https://github.com/matterport/layout-bmfont-text#e9becf5899d055497b7d8401d16163bdaf8a0c17",
     "nice-color-palettes": "^3.0.0",
     "object-assign": "^4.0.1",
     "quad-indices": "^2.0.1"


### PR DESCRIPTION
For yarn upgrade, use full hash when referencing layout-bmfont-text dependency